### PR TITLE
Level2 - Existing or Net New

### DIFF
--- a/docs/configuration.yml
+++ b/docs/configuration.yml
@@ -244,6 +244,11 @@ infra:
         private_route_table:
         public_route_table_suffix:
         private_route_table_suffix:
+      existing:
+        vpcId:
+        public_subnet_ids:
+        private_subnet_ids:
+        onprem_cidrs_for_security_groups:
   azure:
     metagroup:
       name:

--- a/docs/configuration.yml
+++ b/docs/configuration.yml
@@ -245,10 +245,9 @@ infra:
         public_route_table_suffix:
         private_route_table_suffix:
       existing:
-        vpcId:
+        vpc_id:
         public_subnet_ids:
         private_subnet_ids:
-        onprem_cidrs_for_security_groups:
   azure:
     metagroup:
       name:
@@ -327,6 +326,7 @@ infra:
       subnet:
     user_cidr:
     user_ports:
+    tunneled_cidrs:
 ml:
   definitions:
   k8s_request_base:

--- a/roles/infrastructure/defaults/main.yml
+++ b/roles/infrastructure/defaults/main.yml
@@ -29,6 +29,7 @@ infra__vpc_public_subnets_suffix:   "{{ common__vpc_public_subnets_suffix }}"
 # Infra
 infra__type:                        "{{ common__infra_type }}"
 infra__tunnel:                      "{{ common__tunnel }}"
+infra__public_endpoint_access:      "{{ common__public_endpoint_access }}"
 
 # Dynamic Inventory for Clusters
 infra__private_key_file:                 "{{ globals.ssh.private_key_file | default('') }}"
@@ -76,6 +77,11 @@ infra__vpc_extra_ports:             "{{ infra.vpc.extra_ports | default([22, 443
 infra__vpc_extra_cidr:              "{{ infra.vpc.extra_cidr | default([]) }}"
 infra__vpc_user_ports:              "{{ infra.vpc.user_ports | default([infra__all_ports_security_rule[infra__type]]) }}"
 infra__vpc_user_cidr:               "{{ infra.vpc.user_cidr | default([]) }}"
+
+infra__aws_vpc_id:                  "{{ infra.aws.vpc.existing.vpcId | default('') }}"
+infra__aws_public_subnet_ids:       "{{ infra.aws.vpc.existing.public_subnet_ids | default([]) }}"
+infra__aws_private_subnet_ids:      "{{ infra.aws.vpc.existing.private_subnet_ids | default([]) }}"
+infra__aws_onprem_cidrs:            "{{ infra.aws.vpc.existing.onprem_cidrs_for_security_groups | default([]) }}"
 
 infra__security_group_knox_name:    "{{ common__security_group_knox_name }}"
 infra__security_group_default_name: "{{ common__security_group_default_name }}"

--- a/roles/infrastructure/defaults/main.yml
+++ b/roles/infrastructure/defaults/main.yml
@@ -77,11 +77,11 @@ infra__vpc_extra_ports:             "{{ infra.vpc.extra_ports | default([22, 443
 infra__vpc_extra_cidr:              "{{ infra.vpc.extra_cidr | default([]) }}"
 infra__vpc_user_ports:              "{{ infra.vpc.user_ports | default([infra__all_ports_security_rule[infra__type]]) }}"
 infra__vpc_user_cidr:               "{{ infra.vpc.user_cidr | default([]) }}"
+infra__vpc_tunneled_cidrs:          "{{ infra.vpc.tunneled_cidrs | default([]) }}"
 
-infra__aws_vpc_id:                  "{{ infra.aws.vpc.existing.vpcId | default('') }}"
+infra__aws_vpc_id:                  "{{ infra.aws.vpc.existing.vpc_id | default('') }}"
 infra__aws_public_subnet_ids:       "{{ infra.aws.vpc.existing.public_subnet_ids | default([]) }}"
 infra__aws_private_subnet_ids:      "{{ infra.aws.vpc.existing.private_subnet_ids | default([]) }}"
-infra__aws_onprem_cidrs:            "{{ infra.aws.vpc.existing.onprem_cidrs_for_security_groups | default([]) }}"
 
 infra__security_group_knox_name:    "{{ common__security_group_knox_name }}"
 infra__security_group_default_name: "{{ common__security_group_default_name }}"

--- a/roles/infrastructure/tasks/initialize_aws.yml
+++ b/roles/infrastructure/tasks/initialize_aws.yml
@@ -29,8 +29,112 @@
     - bucket: "{{ infra__storage_name }}"
       path: "{{ infra__ranger_audit_path }}"
 
-- name: Fetch the AWS VPC id
-  when: infra__aws_vpc_id == ""
+# Will discover VPC ID as well
+- name: Confirm existing AWS Public and Private Subnet details if provided
+  when: infra__aws_private_subnet_ids or infra__aws_public_subnet_ids
+  block:
+    - name: Handle existing AWS Private Subnets
+      when: infra__aws_private_subnet_ids
+      block:
+        - name: Fetch AWS private subnets info
+          amazon.aws.ec2_vpc_subnet_info:
+            subnet_ids: "{{ infra__aws_private_subnet_ids }}"
+          register: __aws_private_subnets_info
+
+        - name: Confirm AWS private subnet AZ count and public IP assignment
+          ansible.builtin.assert:
+            that:
+              - __aws_private_subnets_info.subnets | map(attribute='availability_zone') | list | unique | count >= infra__aws_vpc_az_count
+              - __aws_private_subnets_info.subnets | map(attribute='map_public_ip_on_launch') | reject() | length > 0
+            fail_msg: "The private subnets should be provided from at least 2 AZs and should have public IP addressing disabled."
+            quiet: yes
+
+        - name: Generate Private Subnet details for update
+          ansible.builtin.set_fact:
+            infra__vpc_private_subnets_info: "{{ infra__vpc_private_subnets_info | default([]) | union([entry]) }}"
+          loop_control:
+            loop_var: __private_subnet_item
+            index_var: __private_subnet_idx
+          loop: "{{ __aws_private_subnets_info }}"
+          vars:
+            entry:
+              name: "{{ [infra__namespace, infra__vpc_private_subnets_suffix, __private_subnet_idx|string] | join('-') }}"
+              cidr: "{{ __private_subnet_item.cidr_block }}"
+              tags:
+                "kubernetes.io/role/internal-elb": "1"
+                "Name": "{{ [infra__namespace, infra__vpc_private_subnets_suffix, __private_subnet_idx|string] | join('-') }}"
+
+        - name: Set facts for existing AWS Private Subnet IDs and associate VPC ID
+          ansible.builtin.set_fact:
+            infra__aws_subnet_ids: "{{ infra__aws_private_subnet_ids }}"
+            infra__aws_vpc_id: "{{ __aws_private_subnets_info.subnets | map(attribute='vpc_id') | list | first }}"
+
+    - name: Handle existing AWS Public Subnets
+      when: infra__aws_public_subnet_ids
+      block:
+        - name: Fetch AWS Public Subnets info 
+          amazon.aws.ec2_vpc_subnet_info:
+            subnet_ids: "{{ infra__aws_public_subnet_ids }}"
+          register: __aws_public_subnets_info
+
+        - name: Confirm AWS Public Subnet AZ count and public IP assignment
+          ansible.builtin.assert:
+            that:
+              - __aws_public_subnets_info.subnets | map(attribute='availability_zone') | list | unique | count >= infra__aws_vpc_az_count
+              - __aws_public_subnets_info.subnets | map(attribute='map_public_ip_on_launch') | select() | length > 0
+            fail_msg: "The public subnets should be associated with at least 2 AZs and should have public IP addressing enabled."
+            quiet: yes
+
+        - name: Confirm additional AWS Public Subnet AZ count if providing Public Endpoint access
+          when: infra__public_endpoint_access
+          ansible.builtin.assert:
+            that: 
+              - infra__aws_private_subnet_ids
+              - infra__aws_public_subnet_ids | unique | count >= __aws_private_subnets_info.subnets | map(attribute='availability_zone') | list | unique | count
+            fail_msg: "The number of public subnets should be at least as many as the number of associated AZs of the private subnets."
+            quiet: yes
+
+        - name: Generate Public Subnet details for creation
+          ansible.builtin.set_fact:
+            infra__vpc_public_subnets_info: "{{ infra__vpc_public_subnets_info | default([]) | union([entry]) }}"
+          loop_control:
+            loop_var: __public_subnet_item
+            index_var: __public_subnet_idx
+          loop: "{{ __aws_public_subnets_info }}"
+          vars:
+            entry:
+              name: "{{ [infra__namespace, infra__vpc_public_subnets_suffix, __public_subnet_idx|string] | join('-') }}"
+              cidr: "{{ __public_subnet_item.cidr_block }}"
+              tags:
+                "kubernetes.io/role/elb": "1"
+                "Name": "{{ [infra__namespace, infra__vpc_public_subnets_suffix, __public_subnet_idx|string] | join('-') }}"
+
+        - name: Set facts for existing AWS Public Subnet IDs
+          ansible.builtin.set_fact:
+            infra__aws_subnet_ids: "{{ infra__aws_subnet_ids | default([]) | union(infra__aws_private_subnet_ids) }}"
+            infra__aws_vpc_id: "{{ __aws_public_subnets_info.subnets | map(attribute='vpc_id') | list | first }}"
+
+    - name: Confirm facts for AWS Subnets
+      ansible.builtin.set_fact:
+        infra__vpc_private_subnets_info: "{{ infra__vpc_private_subnets_info | default([]) }}"
+        infra__vpc_public_subnets_info: "{{ infra__vpc_public_subnets_info | default([]) }}"
+
+- name: Confirm existing AWS VPC if provided
+  when: infra__aws_vpc_id
+  block:
+    - name: Confirm AWS VPC ID
+      amazon.aws.ec2_vpc_net_info:
+        vpc_ids: "{{ infra__aws_vpc_id }}"
+      register: __aws_vpc_list
+      failed_when: not __aws_vpc_list.vpcs
+
+    - name: Set facts for existing AWS VPC CIDR block and Name
+      ansible.builtin.set_fact:
+        infra__vpc_cidr: "{{ __aws_vpc_list.vpcs[0].cidr_block }}"
+        infra__vpc_name: "{{ __aws_vpc_list.vpcs[0].tags['Name'] }}"
+
+- name: Discover possible existing AWS VPC details
+  when: not infra__aws_vpc_id
   block:
     - name: Query AWS VPCs by unique name and CIDR
       amazon.aws.ec2_vpc_net_info:
@@ -38,22 +142,19 @@
         filters:
           "tag:Name": "{{ infra__vpc_name }}*"
           cidr: "{{ infra__vpc_cidr }}"
-      register: __aws_vpc_list
+      register: __aws_vpc_list_discovered
 
     - name: Check VPC list for singular response
-      when: __aws_vpc_list.vpcs | count > 1
+      when: __aws_vpc_list_discovered.vpcs | count > 1
       ansible.builtin.fail:
-        msg: "Found more than one VPC matching name and CIDR"
+        msg: "Found more than one VPC matching name, {{ infra__vpc_name }}, and CIDR, {{ infra__vpc_cidr }}."
 
     - name: Set fact for AWS VPC ID parameter on a unique response
-      when: __aws_vpc_list.vpcs | count == 1
+      when: __aws_vpc_list_discovered.vpcs | count == 1
       ansible.builtin.set_fact:
-        infra__aws_vpc_id: "{{ __aws_vpc_list.vpcs[0].vpc_id }}"
-
-    - name: Reset and set fact for AWS VPC ID if none found
-      when: __aws_vpc_list.vpcs | count < 1
-      ansible.builtin.set_fact:
-        infra__aws_vpc_id: ""
+        infra__aws_vpc_id: "{{ __aws_vpc_list_discovered.vpcs[0].vpc_id }}"
+        infra__vpc_cidr: "{{ __aws_vpc_list_discovered.vpcs[0].cidr_block }}"
+        infra__vpc_name: "{{ __aws_vpc_list_discovered.vpcs[0].tags['Name'] }}"
 
 - name: Fetch EC2 Instance info for Dynamic Inventory Nodes
   register: __infra_dynamic_inventory_discovered

--- a/roles/infrastructure/tasks/initialize_aws.yml
+++ b/roles/infrastructure/tasks/initialize_aws.yml
@@ -29,28 +29,31 @@
     - bucket: "{{ infra__storage_name }}"
       path: "{{ infra__ranger_audit_path }}"
 
-- name: Query AWS VPCs by unique name and CIDR
-  amazon.aws.ec2_vpc_net_info:
-    region: "{{ infra__region }}"
-    filters:
-      "tag:Name": "{{ infra__vpc_name }}*"
-      cidr: "{{ infra__vpc_cidr }}"
-  register: __aws_vpc_list
+- name: Fetch the AWS VPC id
+  when: infra__aws_vpc_id == ""
+  block:
+    - name: Query AWS VPCs by unique name and CIDR
+      amazon.aws.ec2_vpc_net_info:
+        region: "{{ infra__region }}"
+        filters:
+          "tag:Name": "{{ infra__vpc_name }}*"
+          cidr: "{{ infra__vpc_cidr }}"
+      register: __aws_vpc_list
 
-- name: Check VPC list for singular response
-  when: __aws_vpc_list.vpcs | count > 1
-  ansible.builtin.fail:
-    msg: "Found more than one VPC matching name and CIDR"
+    - name: Check VPC list for singular response
+      when: __aws_vpc_list.vpcs | count > 1
+      ansible.builtin.fail:
+        msg: "Found more than one VPC matching name and CIDR"
 
-- name: Set fact for AWS VPC ID parameter on a unique response
-  when: __aws_vpc_list.vpcs | count == 1
-  ansible.builtin.set_fact:
-    infra__aws_vpc_id: "{{ __aws_vpc_list.vpcs[0].vpc_id }}"
+    - name: Set fact for AWS VPC ID parameter on a unique response
+      when: __aws_vpc_list.vpcs | count == 1
+      ansible.builtin.set_fact:
+        infra__aws_vpc_id: "{{ __aws_vpc_list.vpcs[0].vpc_id }}"
 
-- name: Reset and set fact for AWS VPC ID if none found
-  when: __aws_vpc_list.vpcs | count < 1
-  ansible.builtin.set_fact:
-    infra__aws_vpc_id: ""
+    - name: Reset and set fact for AWS VPC ID if none found
+      when: __aws_vpc_list.vpcs | count < 1
+      ansible.builtin.set_fact:
+        infra__aws_vpc_id: ""
 
 - name: Fetch EC2 Instance info for Dynamic Inventory Nodes
   register: __infra_dynamic_inventory_discovered

--- a/roles/infrastructure/tasks/initialize_base.yml
+++ b/roles/infrastructure/tasks/initialize_base.yml
@@ -37,7 +37,9 @@
     msg: "{{ infra__tags }}"
     verbosity: 1
 
-- name: Generate Public Subnet details
+# TODO: Consider option to make existing subnet details generic?
+- name: Generate Public Subnet details for creation
+  when: not infra__aws_public_subnet_ids
   ansible.builtin.set_fact:
     infra__vpc_public_subnets_info: "{{ infra__vpc_public_subnets_info | default([]) | union([entry]) }}"
   loop_control:
@@ -52,7 +54,8 @@
         "kubernetes.io/role/elb": "1"
         "Name": "{{ [infra__namespace, infra__vpc_public_subnets_suffix, __public_subnet_idx|string] | join('-') }}"
 
-- name: Generate Private Subnet Details
+- name: Generate Private Subnet Details for creation
+  when: not infra__aws_private_subnet_ids
   ansible.builtin.set_fact:
     infra__vpc_private_subnets_info: "{{ infra__vpc_private_subnets_info | default([]) | union([entry]) }}"
   loop_control:

--- a/roles/infrastructure/tasks/initialize_setup_aws.yml
+++ b/roles/infrastructure/tasks/initialize_setup_aws.yml
@@ -90,6 +90,19 @@
         ports: "{{ infra__vpc_extra_ports }}"
         cidr_ip: "{{ infra__vpc_extra_cidr }}"
 
+- name: Prepare AWS Security Group Rules for on-prem based setups.
+  when: infra__tunnel
+  ansible.builtin.set_fact:
+    infra__aws_security_group_rules: "{{ infra__aws_security_group_rules | union([rule]) }}"
+  loop_control:
+    loop_var: __onprem_cidr
+  loop: "{{ infra__aws_onprem_cidrs }}"
+  vars:
+    rule:
+      proto: all
+      ports: 0-65535
+      cidr_ip: "{{ __onprem_cidr }}"
+
 - name: Add CDP Public Cloud security group rules for AWS
   when: not infra__tunnel
   ansible.builtin.set_fact:

--- a/roles/infrastructure/tasks/initialize_setup_aws.yml
+++ b/roles/infrastructure/tasks/initialize_setup_aws.yml
@@ -77,7 +77,7 @@
       ansible.builtin.set_fact:
         __infra_aws_ami_info: "{{ __infra_aws_ami_list.images | selectattr('name', 'defined') | sort(attribute='creation_date') | last }}"
 
-- name: Prepare AWS Security Group Rules
+- name: Prepare user and extra AWS Security Group rules
   ansible.builtin.set_fact:
     infra__aws_security_group_rules:
       - proto: all
@@ -90,20 +90,20 @@
         ports: "{{ infra__vpc_extra_ports }}"
         cidr_ip: "{{ infra__vpc_extra_cidr }}"
 
-- name: Prepare AWS Security Group Rules for on-prem based setups.
+- name: Add CCM Tunneled deployment AWS Security Group rules 
   when: infra__tunnel
   ansible.builtin.set_fact:
     infra__aws_security_group_rules: "{{ infra__aws_security_group_rules | union([rule]) }}"
   loop_control:
-    loop_var: __onprem_cidr
-  loop: "{{ infra__aws_onprem_cidrs }}"
+    loop_var: __tunnel_cidr
+  loop: "{{ infra__vpc_tunneled_cidrs }}"
   vars:
     rule:
       proto: all
       ports: 0-65535
-      cidr_ip: "{{ __onprem_cidr }}"
+      cidr_ip: "{{ __tunnel_cidr }}"
 
-- name: Add CDP Public Cloud security group rules for AWS
+- name: Add CDP Public Cloud deployment AWS Security Group rules
   when: not infra__tunnel
   ansible.builtin.set_fact:
     infra__aws_security_group_rules: "{{ infra__aws_security_group_rules | union([rule]) }}"

--- a/roles/infrastructure/tasks/setup_aws_network.yml
+++ b/roles/infrastructure/tasks/setup_aws_network.yml
@@ -14,23 +14,36 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Set up AWS Network Infrastructure if not provided
-  when: infra__aws_subnet_ids is undefined
+- name: Set up AWS VPC
+  amazon.aws.ec2_vpc_net:
+    region: "{{ infra__region }}"
+    name: "{{ infra__vpc_name }}"
+    cidr_block: "{{ infra__vpc_cidr }}"
+    tags: "{{ infra__tags }}" # TODO - Filter out name, per module warning
+    state: present
+  register: __aws_vpc_info
+
+- name: Set fact for AWS VPC ID
+  ansible.builtin.set_fact:
+    infra__aws_vpc_id: "{{ __aws_vpc_info.vpc.id }}"
+
+- name: Update existing AWS VPC Public and Private Subnets
+  when: infra__aws_subnet_ids
+  amazon.aws.ec2_vpc_subnet:
+    region: "{{ infra__region }}"
+    vpc_id: "{{ infra__aws_vpc_id }}"
+    cidr: "{{ __aws_subnet_item.cidr }}"
+    state: present
+    tags: "{{ infra__tags | combine(__aws_subnet_item.tags, recursive=True) }}"
+  loop_control:
+    loop_var: __aws_subnet_item
+    index_var: __aws_subnet_index
+  loop: "{{ infra__vpc_private_subnets_info | union(infra__vpc_public_subnets_info) }}"
+
+- name: Set up AWS Public Network infrastructure
+  when: (infra__tunnel == infra__public_endpoint_access) and not infra__aws_subnet_ids  # L0 (all public) or L1 (public/private)
   block:
-    - name: Create AWS VPC
-      amazon.aws.ec2_vpc_net:
-        region: "{{ infra__region }}"
-        name: "{{ infra__vpc_name }}"
-        cidr_block: "{{ infra__vpc_cidr }}"
-        tags: "{{ infra__tags }}" # TODO - Filter out name, per module warning
-        state: present
-      register: __aws_vpc_info
-
-    - name: Set fact for AWS VPC ID
-      ansible.builtin.set_fact:
-        infra__aws_vpc_id: "{{ __aws_vpc_info.vpc.id }}"
-
-    - name: Create IGW
+    - name: Create AWS Internet Gateway (IGW)
       community.aws.ec2_vpc_igw:
         vpc_id: "{{ infra__aws_vpc_id }}"
         region: "{{ infra__region }}"
@@ -38,7 +51,7 @@
         tags: "{{ infra__tags | combine({ 'Name': infra__aws_igw_name }, recursive=True) }}"
       register: __aws_igw
 
-    - name: Set fact for IGW ID
+    - name: Set fact for AWS IGW ID
       when: __aws_igw.gateway_id is defined
       ansible.builtin.set_fact:
         infra__aws_igw_id: "{{ __aws_igw.gateway_id }}"
@@ -49,7 +62,7 @@
         vpc_id: "{{ infra__aws_vpc_id }}"
         cidr: "{{ __aws_public_subnet_item.cidr }}"
         state: present
-        tags: "{{ infra__tags | combine(__aws_public_subnet_item.tags, recursive = true) }}"
+        tags: "{{ infra__tags | combine(__aws_public_subnet_item.tags, recursive=True) }}"
         map_public: yes
         az: "{{ __aws_az_info.availability_zones[__aws_subnet_index % infra__aws_vpc_az_count | int].zone_name }}"
       loop_control:
@@ -65,14 +78,14 @@
         loop_var: __aws_subnet_item
       loop: "{{ __aws_public_subnets.results }}"
 
-    - name: List the Route Tables for the VPC
+    - name: List the Route Tables for the AWS VPC
       community.aws.ec2_vpc_route_table_info:
         region: "{{ infra__region }}"
         filters:
           vpc-id: "{{ infra__aws_vpc_id }}"
       register: __aws_route_table_list
 
-    - name: Configure the Public Route Table
+    - name: Configure the Public Route Table for the AWS VPC
       community.aws.ec2_vpc_route_table:
         region: "{{ infra__region }}"
         vpc_id: "{{ infra__aws_vpc_id }}"
@@ -88,13 +101,13 @@
         __aws_route_table_id: "{{ __aws_route_table_list.route_tables | json_query(__aws_rtb_jq) | flatten | first }}"
         __aws_rtb_jq: "[*].associations[?main == `true` ].route_table_id"
 
-    - name: Set the fact for Subnet Ids
+    - name: Set facts for AWS Subnet IDs with Public Subnet details if not CCM Tunneled
       when: not infra__tunnel
       ansible.builtin.set_fact:
         infra__aws_subnet_ids: "{{ infra__aws_public_subnet_ids }}"
 
-- name: Setup for private networking when tunneling is enabled for a new infra setup.
-  when: infra__tunnel and (infra__aws_subnet_ids is undefined)
+- name: Setup AWS Private Networking infrastructure
+  when: infra__tunnel and not infra__aws_subnet_ids # L1 (public/private) or L2 (all private)
   block:
     - name: Create AWS VPC Private Subnets
       amazon.aws.ec2_vpc_subnet:
@@ -119,7 +132,7 @@
         loop_var: __aws_subnet_item
       loop: "{{ __aws_private_subnets.results }}"
 
-    - name: Creates NAT gateways and allocates EIPs
+    - name: Create Network Gateways (NAT) and allocate Elastic IP Addresses (EIP) for the AWS VPC
       community.aws.ec2_vpc_nat_gateway:
         state: present
         subnet_id: "{{ __aws_public_subnet_id }}"
@@ -133,7 +146,7 @@
       loop: "{{ infra__aws_public_subnet_ids }}"
       register: __aws_ngws
 
-    - name: Configure Private Route Tables
+    - name: Configure Private Route Tables for the AWS VPC
       community.aws.ec2_vpc_route_table:
         vpc_id: "{{ infra__aws_vpc_id }}"
         region: "{{ infra__region }}"
@@ -147,7 +160,7 @@
         index_var: __aws_private_subnet_id_index
       loop: "{{ infra__aws_private_subnet_ids }}"
 
-    - name: Set fact for Subnet Ids
+    - name: Set fact for AWS Subnet IDs
       ansible.builtin.set_fact:
         infra__aws_subnet_ids: "{{ infra__aws_public_subnet_ids | union(infra__aws_private_subnet_ids) }}"
 

--- a/roles/infrastructure/tasks/setup_aws_network.yml
+++ b/roles/infrastructure/tasks/setup_aws_network.yml
@@ -14,85 +14,87 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Create AWS VPC
-  amazon.aws.ec2_vpc_net:
-    region: "{{ infra__region }}"
-    name: "{{ infra__vpc_name }}"
-    cidr_block: "{{ infra__vpc_cidr }}"
-    tags: "{{ infra__tags }}" # TODO - Filter out name, per module warning
-    state: present
-  register: __aws_vpc_info
+- name: Set up AWS Network Infrastructure if not provided
+  when: infra__aws_subnet_ids is undefined
+  block:
+    - name: Create AWS VPC
+      amazon.aws.ec2_vpc_net:
+        region: "{{ infra__region }}"
+        name: "{{ infra__vpc_name }}"
+        cidr_block: "{{ infra__vpc_cidr }}"
+        tags: "{{ infra__tags }}" # TODO - Filter out name, per module warning
+        state: present
+      register: __aws_vpc_info
 
-- name: Set fact for AWS VPC ID
-  ansible.builtin.set_fact:
-    infra__aws_vpc_id: "{{ __aws_vpc_info.vpc.id }}"
+    - name: Set fact for AWS VPC ID
+      ansible.builtin.set_fact:
+        infra__aws_vpc_id: "{{ __aws_vpc_info.vpc.id }}"
 
-- name: Create IGW 
-  community.aws.ec2_vpc_igw:
-    vpc_id: "{{ infra__aws_vpc_id }}"
-    region: "{{ infra__region }}"
-    state: present
-    tags: "{{ infra__tags | combine({ 'Name': infra__aws_igw_name }, recursive=True) }}"
-  register: __aws_igw
+    - name: Create IGW
+      community.aws.ec2_vpc_igw:
+        vpc_id: "{{ infra__aws_vpc_id }}"
+        region: "{{ infra__region }}"
+        state: present
+        tags: "{{ infra__tags | combine({ 'Name': infra__aws_igw_name }, recursive=True) }}"
+      register: __aws_igw
 
-- name: Set fact for IGW ID
-  when: __aws_igw.gateway_id is defined
-  ansible.builtin.set_fact:
-    infra__aws_igw_id: "{{ __aws_igw.gateway_id }}"
+    - name: Set fact for IGW ID
+      when: __aws_igw.gateway_id is defined
+      ansible.builtin.set_fact:
+        infra__aws_igw_id: "{{ __aws_igw.gateway_id }}"
 
-- name: Create AWS VPC Public Subnets
-  amazon.aws.ec2_vpc_subnet:
-    region: "{{ infra__region }}"
-    vpc_id: "{{ infra__aws_vpc_id }}"
-    cidr: "{{ __aws_public_subnet_item.cidr }}"
-    state: present
-    tags: "{{ infra__tags | combine(__aws_public_subnet_item.tags, recursive = true) }}"
-    map_public: yes
-    az: "{{ __aws_az_info.availability_zones[__aws_subnet_index % infra__aws_vpc_az_count | int].zone_name }}"
-  loop_control:
-    loop_var: __aws_public_subnet_item
-    index_var: __aws_subnet_index
-  loop: "{{ infra__vpc_public_subnets_info }}"
-  register: __aws_public_subnets
+    - name: Create AWS VPC Public Subnets
+      amazon.aws.ec2_vpc_subnet:
+        region: "{{ infra__region }}"
+        vpc_id: "{{ infra__aws_vpc_id }}"
+        cidr: "{{ __aws_public_subnet_item.cidr }}"
+        state: present
+        tags: "{{ infra__tags | combine(__aws_public_subnet_item.tags, recursive = true) }}"
+        map_public: yes
+        az: "{{ __aws_az_info.availability_zones[__aws_subnet_index % infra__aws_vpc_az_count | int].zone_name }}"
+      loop_control:
+        loop_var: __aws_public_subnet_item
+        index_var: __aws_subnet_index
+      loop: "{{ infra__vpc_public_subnets_info }}"
+      register: __aws_public_subnets
 
-- name: Set fact for AWS Public Subnet IDs
-  ansible.builtin.set_fact:
-    infra__aws_public_subnet_ids: "{{ infra__aws_public_subnet_ids | default([]) | union([__aws_subnet_item.subnet.id | default('')]) }}"
-  loop_control:
-    loop_var: __aws_subnet_item
-    label: "{{ __aws_subnet_item.subnet.id }}"
-  loop: "{{ __aws_public_subnets.results }}"
+    - name: Set fact for AWS Public Subnet IDs
+      ansible.builtin.set_fact:
+        infra__aws_public_subnet_ids: "{{ infra__aws_public_subnet_ids | default([]) | union([__aws_subnet_item.subnet.id | default('')]) }}"
+      loop_control:
+        loop_var: __aws_subnet_item
+      loop: "{{ __aws_public_subnets.results }}"
 
-- name: List the Route Tables for the VPC
-  community.aws.ec2_vpc_route_table_info:
-    region: "{{ infra__region }}"
-    filters:
-      vpc-id: "{{ infra__aws_vpc_id }}"
-  register: __aws_route_table_list
+    - name: List the Route Tables for the VPC
+      community.aws.ec2_vpc_route_table_info:
+        region: "{{ infra__region }}"
+        filters:
+          vpc-id: "{{ infra__aws_vpc_id }}"
+      register: __aws_route_table_list
 
-- name: Configure the Public Route Table
-  community.aws.ec2_vpc_route_table:
-    region: "{{ infra__region }}"
-    vpc_id: "{{ infra__aws_vpc_id }}"
-    route_table_id: "{{ __aws_route_table_id }}"
-    lookup: id
-    state: present
-    tags: "{{ infra__tags | combine({ 'Name': infra__aws_public_route_table_name }, recursive=True) }}"
-    routes:
-      - dest: "0.0.0.0/0"
-        gateway_id: "{{ infra__aws_igw_id }}"
-    subnets: "{{ infra__aws_public_subnet_ids }}"
-  vars:
-    __aws_route_table_id: "{{ __aws_route_table_list.route_tables | json_query(__aws_rtb_jq) | flatten | first }}"
-    __aws_rtb_jq: "[*].associations[?main == `true` ].route_table_id"
+    - name: Configure the Public Route Table
+      community.aws.ec2_vpc_route_table:
+        region: "{{ infra__region }}"
+        vpc_id: "{{ infra__aws_vpc_id }}"
+        route_table_id: "{{ __aws_route_table_id }}"
+        lookup: id
+        state: present
+        tags: "{{ infra__tags | combine({ 'Name': infra__aws_public_route_table_name }, recursive=True) }}"
+        routes:
+          - dest: "0.0.0.0/0"
+            gateway_id: "{{ infra__aws_igw_id }}"
+        subnets: "{{ infra__aws_public_subnet_ids }}"
+      vars:
+        __aws_route_table_id: "{{ __aws_route_table_list.route_tables | json_query(__aws_rtb_jq) | flatten | first }}"
+        __aws_rtb_jq: "[*].associations[?main == `true` ].route_table_id"
 
-- name: Set the fact for Subnet Ids
-  when: not infra__tunnel
-  ansible.builtin.set_fact:
-    infra__aws_subnet_ids: "{{ infra__aws_public_subnet_ids }}"
+    - name: Set the fact for Subnet Ids
+      when: not infra__tunnel
+      ansible.builtin.set_fact:
+        infra__aws_subnet_ids: "{{ infra__aws_public_subnet_ids }}"
 
-- name: Setup for private networking
-  when: infra__tunnel
+- name: Setup for private networking when tunneling is enabled for a new infra setup.
+  when: infra__tunnel and (infra__aws_subnet_ids is undefined)
   block:
     - name: Create AWS VPC Private Subnets
       amazon.aws.ec2_vpc_subnet:
@@ -116,10 +118,6 @@
       loop_control:
         loop_var: __aws_subnet_item
       loop: "{{ __aws_private_subnets.results }}"
-
-    - name: Set fact for Subnet Ids
-      ansible.builtin.set_fact:
-        infra__aws_subnet_ids: "{{ infra__aws_public_subnet_ids | union(infra__aws_private_subnet_ids) }}"
 
     - name: Creates NAT gateways and allocates EIPs
       community.aws.ec2_vpc_nat_gateway:
@@ -148,6 +146,10 @@
         loop_var: __aws_private_subnet_id_item
         index_var: __aws_private_subnet_id_index
       loop: "{{ infra__aws_private_subnet_ids }}"
+
+    - name: Set fact for Subnet Ids
+      ansible.builtin.set_fact:
+        infra__aws_subnet_ids: "{{ infra__aws_public_subnet_ids | union(infra__aws_private_subnet_ids) }}"
 
 - name: Create Security Groups
   amazon.aws.ec2_group:

--- a/roles/infrastructure/tasks/validate_aws.yml
+++ b/roles/infrastructure/tasks/validate_aws.yml
@@ -30,56 +30,12 @@
 - name: Print AWS Profile to debug
   ansible.builtin.command: echo AWS_PROFILE is $AWS_PROFILE
 
-- name: Validate the vpcId and subnet Ids if provided for a private network
-  when: infra__aws_vpc_id != ""
+# TODO: Revisit this logic, we could just provide a blank VPC for L0, L1, or L2
+- name: Validate existing AWS Subnet details if provided for a private network
+  #when: infra__aws_vpc_id != "" 
+  when: no
   block:
-  - name: Validate the vpc Id
-    amazon.aws.ec2_vpc_net_info:
-      vpc_ids: "{{ infra__aws_vpc_id }}"
-    register: __aws_vpc_list
-    failed_when: __aws_vpc_list.vpcs is undefined
-
-  - name: Check for non-empty private subnets list
-    when: infra__aws_private_subnet_ids | unique | count < 3
-    ansible.builtin.fail:
-      msg: "At least 3 private subnets need to be provided."
-
-  - name: Fetch the private subnets info.
-    amazon.aws.ec2_vpc_subnet_info:
-      subnet_ids: "{{ infra__aws_private_subnet_ids }}"
-    register: __aws_private_subnets_info
-
-  - name: Derive the number of AZs the private subnets belong to
-    set_fact:
-      __private_subnets_azs_count : "{{ __aws_private_subnets_info.subnets | map(attribute='availability_zone') | list | unique | count }}"
-
-  - name: Validate the Private Subnets
-    when: (__private_subnets_azs_count < infra__aws_vpc_az_count) or
-          (True in (__aws_private_subnets_info.subnets | map(attribute='map_public_ip_on_launch')))
-    ansible.builtin.fail:
-      msg: "The private subnets should be provided from at least 2 AZs and should have public IP addressing disabled"
-
-  - name: Check for non-empty public subnets list
-    when: infra__public_endpoint_access and ((infra__aws_public_subnet_ids | unique | count) < (__private_subnets_azs_count | int))
-    ansible.builtin.fail:
-      msg: "There should be at least as many public subnets as the numbers of AZs the input private subnets reside in."
-
-  - name: Fetch the public subnets info.
-    when: infra__public_endpoint_access
-    amazon.aws.ec2_vpc_subnet_info:
-      subnet_ids: "{{ infra__aws_public_subnet_ids }}"
-    register: __aws_public_subnets_info
-
-  - name: Validate the Public Subnet
-    when: infra__public_endpoint_access and
-          (__aws_public_subnets_info.subnets | map(attribute='availability_zone') | list | unique | count < (__private_subnets_azs_count | int))
-    ansible.builtin.fail:
-      msg: "The public subnets should be provided from at least 2 AZs and should have public IP addressing disabled"
-
-  # Set the facts for subsequent plays to pick them up.
-  - name: Set fact for VPC Id and subnet Ids.
-    ansible.builtin.set_fact:
-      infra__aws_vpc_id: "{{ infra__aws_vpc_id }}"
-      infra__aws_public_subnet_ids: "{{ infra__aws_public_subnet_ids }}"
-      infra__aws_subnet_ids: "{{ infra__aws_private_subnet_ids }}"
-      infra__vpc_cidr: "{{ __aws_vpc_list.vpcs[0].cidr_block }}"
+    - name: Check for non-empty AWS private subnets
+      when: infra__aws_private_subnet_ids | unique | count < 3
+      ansible.builtin.fail:
+        msg: "At least 3 private subnets need to be provided if specifying and existing AWS VPC."

--- a/roles/infrastructure/tasks/validate_aws.yml
+++ b/roles/infrastructure/tasks/validate_aws.yml
@@ -29,3 +29,57 @@
 
 - name: Print AWS Profile to debug
   ansible.builtin.command: echo AWS_PROFILE is $AWS_PROFILE
+
+- name: Validate the vpcId and subnet Ids if provided for a private network
+  when: infra__aws_vpc_id != ""
+  block:
+  - name: Validate the vpc Id
+    amazon.aws.ec2_vpc_net_info:
+      vpc_ids: "{{ infra__aws_vpc_id }}"
+    register: __aws_vpc_list
+    failed_when: __aws_vpc_list.vpcs is undefined
+
+  - name: Check for non-empty private subnets list
+    when: infra__aws_private_subnet_ids | unique | count < 3
+    ansible.builtin.fail:
+      msg: "At least 3 private subnets need to be provided."
+
+  - name: Fetch the private subnets info.
+    amazon.aws.ec2_vpc_subnet_info:
+      subnet_ids: "{{ infra__aws_private_subnet_ids }}"
+    register: __aws_private_subnets_info
+
+  - name: Derive the number of AZs the private subnets belong to
+    set_fact:
+      __private_subnets_azs_count : "{{ __aws_private_subnets_info.subnets | map(attribute='availability_zone') | list | unique | count }}"
+
+  - name: Validate the Private Subnets
+    when: (__private_subnets_azs_count < infra__aws_vpc_az_count) or
+          (True in (__aws_private_subnets_info.subnets | map(attribute='map_public_ip_on_launch')))
+    ansible.builtin.fail:
+      msg: "The private subnets should be provided from at least 2 AZs and should have public IP addressing disabled"
+
+  - name: Check for non-empty public subnets list
+    when: infra__public_endpoint_access and ((infra__aws_public_subnet_ids | unique | count) < (__private_subnets_azs_count | int))
+    ansible.builtin.fail:
+      msg: "There should be at least as many public subnets as the numbers of AZs the input private subnets reside in."
+
+  - name: Fetch the public subnets info.
+    when: infra__public_endpoint_access
+    amazon.aws.ec2_vpc_subnet_info:
+      subnet_ids: "{{ infra__aws_public_subnet_ids }}"
+    register: __aws_public_subnets_info
+
+  - name: Validate the Public Subnet
+    when: infra__public_endpoint_access and
+          (__aws_public_subnets_info.subnets | map(attribute='availability_zone') | list | unique | count < (__private_subnets_azs_count | int))
+    ansible.builtin.fail:
+      msg: "The public subnets should be provided from at least 2 AZs and should have public IP addressing disabled"
+
+  # Set the facts for subsequent plays to pick them up.
+  - name: Set fact for VPC Id and subnet Ids.
+    ansible.builtin.set_fact:
+      infra__aws_vpc_id: "{{ infra__aws_vpc_id }}"
+      infra__aws_public_subnet_ids: "{{ infra__aws_public_subnet_ids }}"
+      infra__aws_subnet_ids: "{{ infra__aws_private_subnet_ids }}"
+      infra__vpc_cidr: "{{ __aws_vpc_list.vpcs[0].cidr_block }}"

--- a/roles/platform/tasks/initialize_setup_aws.yml
+++ b/roles/platform/tasks/initialize_setup_aws.yml
@@ -92,6 +92,7 @@
   ansible.builtin.set_fact:
     plat__aws_subnet_ids: "{{ infra__aws_subnet_ids }}"
 
+# TODO: Discover AWS VPC Public Subnets if infra__ is not present
 - name: Set public subnets for public endpoint access
   when: plat__public_endpoint_access
   ansible.builtin.set_fact:

--- a/roles/runtime/tasks/initialize_setup_aws.yml
+++ b/roles/runtime/tasks/initialize_setup_aws.yml
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 - name: Discover AWS Public and Private VPC Subnets
-  when: infra__aws_subnet_ids is undefined
+  when: not infra__aws_subnet_ids
   block:
     - name: Query AWS Public Subnets
       amazon.aws.ec2_vpc_subnet_info:
@@ -55,7 +55,7 @@
         run__datahub_subnet_ids: "{{ run__datahub_public_subnet_ids | default([]) | union(run__datahub_private_subnet_ids) }}"
 
 - name: Set fact for AWS Subnet IDs by assignment
-  when: infra__aws_subnet_ids is defined
+  when: infra__aws_subnet_ids
   block:
     - name: Set fact for All AWS Subnet IDs by assignment
       ansible.builtin.set_fact:


### PR DESCRIPTION
A bunch of changes in an attempt to handle existing and net new assets for L0, L1, and L2 networking.  Only have touched `infrastructure` in this set of work.

Focus areas:
* Existing assets only need to be updated for tags regardless of Level; all other network assets, e.g. NATs, are assumed to exist as well
** I hope this handles RAM Resource Shares
* L2 should also be set up net new, no existing/shared assets
** Additional, out-of-band work would need to be performed by the network admin to provide DC/VPN access to the VPC
* All Levels can be handed an existing, empty VPC

Lastly, I squash merged the L1 PR earlier today into `devel`, then created this branch from the new `devel` branch, and cherrypicked the single commit that made up the `existing_networks` branch. I wasn't sure what to do since `existing_networks` was branched from all of the commits that got squashed. Possibly update your personal `devel` to match upstream, fork a new feature branch, and change the base for this PR?
