### PR TITLE
Updates to handle L0, L1, and L2

### DIFF
--- a/roles/infrastructure/tasks/initialize_aws.yml
+++ b/roles/infrastructure/tasks/initialize_aws.yml
@@ -124,7 +124,7 @@
         infra__vpc_public_subnets_info: "{{ infra__vpc_public_subnets_info | default([]) }}"
 
 - name: Query existing AWS VPC if provided
-  when: infra__aws_vpc_id
+  when: infra__aws_vpc_id != ""
   block:
     - name: Confirm AWS VPC ID
       when: no # Skipped due to https://github.com/boto/boto3/issues/2929
@@ -157,7 +157,7 @@
         infra__vpc_cidr: "{{ (__aws_vpc_list.stdout | from_json)['Vpcs'] | map(attribute='CidrBlock') | list | first }}"
 
 - name: Discover possible existing AWS VPC details
-  when: not infra__aws_vpc_id
+  when: infra__aws_vpc_id == ""
   block:
     - name: Query AWS VPCs by unique name and CIDR
       when: no # Skipped due to https://github.com/boto/boto3/issues/2929
@@ -185,7 +185,7 @@
     - name: Query AWS VPC ID by unique name and CIDR (CLI version)
       ansible.builtin.command: "aws ec2 describe-vpcs --region {{ infra__region }} --filters Name=cidr,Values={{ infra__vpc_cidr }} Name=tag:Name,Values={{ infra__vpc_name }}"
       register: __aws_vpc_list_discovered
-      failed_when: not (__aws_vpc_list_discovered.stdout | from_json)['Vpcs']
+      #failed_when: not (__aws_vpc_list_discovered.stdout | from_json)['Vpcs']
 
     - name: Check VPC list for singular response (CLI version)
       when: (__aws_vpc_list_discovered.stdout | from_json)['Vpcs'] | count > 1
@@ -193,12 +193,11 @@
         msg: "Found more than one VPC matching name, {{ infra__vpc_name }}, and CIDR, {{ infra__vpc_cidr }}."
 
     - name: Set fact for AWS VPC ID parameter on a unique response (CLI version)
-      when: (__aws_vpc_list_discovered | from_json)['Vpcs'] | count == 1
+      when: (__aws_vpc_list_discovered.stdout | from_json)['Vpcs'] | count == 1
       ansible.builtin.set_fact:
-        infra__aws_vpc_id: "{{ (__aws_vpc_list_discovered | from_json)['Vpcs'] | map(attribute='VpcId') | list | first }}"
+        infra__aws_vpc_id: "{{ (__aws_vpc_list_discovered.stdout | from_json)['Vpcs'] | map(attribute='VpcId') | list | first }}"
         #infra__vpc_cidr: "{{ __aws_vpc_list_discovered.vpcs[0].cidr_block }}"
         #infra__vpc_name: "{{ __aws_vpc_list_discovered.vpcs[0].tags['Name'] }}"
-
 
 - name: Fetch EC2 Instance info for Dynamic Inventory Nodes
   register: __infra_dynamic_inventory_discovered

--- a/roles/infrastructure/tasks/initialize_aws.yml
+++ b/roles/infrastructure/tasks/initialize_aws.yml
@@ -38,6 +38,7 @@
       block:
         - name: Fetch AWS private subnets info
           amazon.aws.ec2_vpc_subnet_info:
+            region: "{{ infra__region }}"
             subnet_ids: "{{ infra__aws_private_subnet_ids }}"
           register: __aws_private_subnets_info
 
@@ -74,6 +75,7 @@
       block:
         - name: Fetch AWS Public Subnets info 
           amazon.aws.ec2_vpc_subnet_info:
+            region: "{{ infra__region }}"
             subnet_ids: "{{ infra__aws_public_subnet_ids }}"
           register: __aws_public_subnets_info
 
@@ -121,24 +123,44 @@
         infra__vpc_private_subnets_info: "{{ infra__vpc_private_subnets_info | default([]) }}"
         infra__vpc_public_subnets_info: "{{ infra__vpc_public_subnets_info | default([]) }}"
 
-- name: Confirm existing AWS VPC if provided
+- name: Query existing AWS VPC if provided
   when: infra__aws_vpc_id
   block:
     - name: Confirm AWS VPC ID
+      when: no # Skipped due to https://github.com/boto/boto3/issues/2929
       amazon.aws.ec2_vpc_net_info:
+        region: "{{ infra__region }}"
         vpc_ids: "{{ infra__aws_vpc_id }}"
       register: __aws_vpc_list
       failed_when: not __aws_vpc_list.vpcs
 
     - name: Set facts for existing AWS VPC CIDR block and Name
+      when: no # Skipped due to https://github.com/boto/boto3/issues/2929
       ansible.builtin.set_fact:
         infra__vpc_cidr: "{{ __aws_vpc_list.vpcs[0].cidr_block }}"
-        infra__vpc_name: "{{ __aws_vpc_list.vpcs[0].tags['Name'] }}"
+        # infra__vpc_name: "{{ __aws_vpc_list.vpcs[0].tags['Name'] }}"
+
+    - name: Confirm AWS VPC ID (CLI version)
+      ansible.builtin.command: "aws ec2 describe-vpcs --region {{ infra__region }} --vpc-id {{ infra__aws_vpc_id }}"
+      register: __aws_vpc_list
+      failed_when: not (__aws_vpc_list.stdout | from_json)['Vpcs']
+
+    - name: Set facts for existing AWS VPC CIDR block and Name (CLI version)
+      when: (__aws_vpc_list.stdout | from_json)['Vpcs']['Tags']
+      ansible.builtin.set_fact:
+        infra__vpc_cidr: "{{ (__aws_vpc_list.stdout | from_json)['Vpcs'] | map(attribute='CidrBlock') | list | first }}"
+        #infra__vpc_name: "{{ (__aws_vpc_list.stdout | from_json)['Vpcs'] | map(attribute='Tags') | flatten | selectattr('Key', 'eq', 'Name') | map(attribute='Value') | list | first }}"
+
+    - name: Set facts for existing AWS VPC Name (CLI version)
+      when: not (__aws_vpc_list.stdout | from_json)['Vpcs']['Tags']
+      ansible.builtin.set_fact:
+        infra__vpc_cidr: "{{ (__aws_vpc_list.stdout | from_json)['Vpcs'] | map(attribute='CidrBlock') | list | first }}"
 
 - name: Discover possible existing AWS VPC details
   when: not infra__aws_vpc_id
   block:
     - name: Query AWS VPCs by unique name and CIDR
+      when: no # Skipped due to https://github.com/boto/boto3/issues/2929
       amazon.aws.ec2_vpc_net_info:
         region: "{{ infra__region }}"
         filters:
@@ -147,16 +169,36 @@
       register: __aws_vpc_list_discovered
 
     - name: Check VPC list for singular response
-      when: __aws_vpc_list_discovered.vpcs | count > 1
+      when: no # Skipped due to https://github.com/boto/boto3/issues/2929
+      #when: __aws_vpc_list_discovered.vpcs | count > 1
       ansible.builtin.fail:
         msg: "Found more than one VPC matching name, {{ infra__vpc_name }}, and CIDR, {{ infra__vpc_cidr }}."
 
     - name: Set fact for AWS VPC ID parameter on a unique response
-      when: __aws_vpc_list_discovered.vpcs | count == 1
+      when: no # Skipped due to https://github.com/boto/boto3/issues/2929
+      #when: __aws_vpc_list_discovered.vpcs | count == 1
       ansible.builtin.set_fact:
         infra__aws_vpc_id: "{{ __aws_vpc_list_discovered.vpcs[0].vpc_id }}"
-        infra__vpc_cidr: "{{ __aws_vpc_list_discovered.vpcs[0].cidr_block }}"
-        infra__vpc_name: "{{ __aws_vpc_list_discovered.vpcs[0].tags['Name'] }}"
+        #infra__vpc_cidr: "{{ __aws_vpc_list_discovered.vpcs[0].cidr_block }}"
+        #infra__vpc_name: "{{ __aws_vpc_list_discovered.vpcs[0].tags['Name'] }}"
+
+    - name: Query AWS VPC ID by unique name and CIDR (CLI version)
+      ansible.builtin.command: "aws ec2 describe-vpcs --region {{ infra__region }} --filters Name=cidr,Values={{ infra__vpc_cidr }} Name=tag:Name,Values={{ infra__vpc_name }}"
+      register: __aws_vpc_list_discovered
+      failed_when: not (__aws_vpc_list_discovered.stdout | from_json)['Vpcs']
+
+    - name: Check VPC list for singular response (CLI version)
+      when: (__aws_vpc_list_discovered.stdout | from_json)['Vpcs'] | count > 1
+      ansible.builtin.fail:
+        msg: "Found more than one VPC matching name, {{ infra__vpc_name }}, and CIDR, {{ infra__vpc_cidr }}."
+
+    - name: Set fact for AWS VPC ID parameter on a unique response (CLI version)
+      when: (__aws_vpc_list_discovered | from_json)['Vpcs'] | count == 1
+      ansible.builtin.set_fact:
+        infra__aws_vpc_id: "{{ (__aws_vpc_list_discovered | from_json)['Vpcs'] | map(attribute='VpcId') | list | first }}"
+        #infra__vpc_cidr: "{{ __aws_vpc_list_discovered.vpcs[0].cidr_block }}"
+        #infra__vpc_name: "{{ __aws_vpc_list_discovered.vpcs[0].tags['Name'] }}"
+
 
 - name: Fetch EC2 Instance info for Dynamic Inventory Nodes
   register: __infra_dynamic_inventory_discovered

--- a/roles/infrastructure/tasks/setup_aws_network.yml
+++ b/roles/infrastructure/tasks/setup_aws_network.yml
@@ -14,25 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Set up AWS VPC
-  when: not infra__aws_vpc_id
-  block:
-    - name: Create AWS VPC
-      amazon.aws.ec2_vpc_net:
-        region: "{{ infra__region }}"
-        name: "{{ infra__vpc_name }}"
-        cidr_block: "{{ infra__vpc_cidr }}"
-        tags: "{{ infra__tags }}" # TODO - Filter out name, per module warning
-        state: present
-      register: __aws_vpc_info
-
-    - name: Set fact for AWS VPC ID
-      when: not infra__aws_vpc_id
-      ansible.builtin.set_fact:
-        infra__aws_vpc_id: "{{ __aws_vpc_info.vpc.id }}"
-
 - name: Update existing AWS VPC
-  when: infra__aws_vpc_id
+  when: infra__aws_vpc_id != ""
   block:
     - name: Update AWS VPC
       when: no # Skipped due to https://github.com/boto/boto3/issues/2929
@@ -48,13 +31,29 @@
       ansible.builtin.set_fact:
         __aws_vpc_tags: "{{ __aws_vpc_tags | default([]) | union([tag_entry]) }}"
       vars:
-        tag_entry: "Key={{ __tag.key }},Value={{ __tag.value }}"
-      loop: "{{ infra__tags }}"
+        tag_entry: "Key={{ __tag.key }},Value={{ __tag.value |quote}}"
+      loop: "{{ infra__tags | dict2items }}"
       loop_control:
         loop_var: __tag
 
     - name: Update AWS VPC (CLI version)
       ansible.builtin.command: "aws ec2 create-tags --region {{ infra__region }} --resources {{ infra__aws_vpc_id }} --tags {{ __aws_vpc_tags | join(' ') }}"
+
+- name: Set up AWS VPC
+  when: infra__aws_vpc_id == ""
+  block:
+    - name: Create AWS VPC
+      amazon.aws.ec2_vpc_net:
+        region: "{{ infra__region }}"
+        name: "{{ infra__vpc_name }}"
+        cidr_block: "{{ infra__vpc_cidr }}"
+        tags: "{{ infra__tags }}" # TODO - Filter out name, per module warning
+        state: present
+      register: __aws_vpc_info
+
+    - name: Set fact for AWS VPC ID
+      ansible.builtin.set_fact:
+        infra__aws_vpc_id: "{{ __aws_vpc_info.vpc.id }}"
 
 - name: Update existing AWS VPC Public and Private Subnets
   when: infra__aws_subnet_ids is defined
@@ -161,7 +160,17 @@
         loop_var: __aws_subnet_item
       loop: "{{ __aws_private_subnets.results }}"
 
-    - name: Create Network Gateways (NAT) and allocate Elastic IP Addresses (EIP) for the AWS VPC
+    - name: Configure Private Route Table for the AWS VPC
+      when: not infra__public_endpoint_access
+      community.aws.ec2_vpc_route_table:
+        vpc_id: "{{ infra__aws_vpc_id }}"
+        region: "{{ infra__region }}"
+        tags: "{{ infra__tags | combine({ 'Name': infra__aws_private_route_table_name }, recursive=True) }}"
+        subnets: "{{ infra__aws_private_subnet_ids }}"
+        routes: []
+
+    - name: Create Network Gateways (NAT) and allocate Elastic IP Addresses (EIP) for Public Endpoint Access
+      when: infra__public_endpoint_access
       community.aws.ec2_vpc_nat_gateway:
         state: present
         subnet_id: "{{ __aws_public_subnet_id }}"
@@ -175,7 +184,8 @@
       loop: "{{ infra__aws_public_subnet_ids }}"
       register: __aws_ngws
 
-    - name: Configure Private Route Tables for the AWS VPC
+    - name: Configure Private Route Tables for the AWS VPC for Public Endpoint Access
+      when: infra__public_endpoint_access
       community.aws.ec2_vpc_route_table:
         vpc_id: "{{ infra__aws_vpc_id }}"
         region: "{{ infra__region }}"
@@ -188,10 +198,11 @@
         loop_var: __aws_private_subnet_id_item
         index_var: __aws_private_subnet_id_index
       loop: "{{ infra__aws_private_subnet_ids }}"
+      debugger: always
 
     - name: Set fact for AWS Subnet IDs
       ansible.builtin.set_fact:
-        infra__aws_subnet_ids: "{{ infra__aws_public_subnet_ids | union(infra__aws_private_subnet_ids) }}"
+        infra__aws_subnet_ids: "{{ infra__aws_public_subnet_ids | default([]) | union(infra__aws_private_subnet_ids) }}"
 
 - name: Create Security Groups
   amazon.aws.ec2_group:

--- a/roles/infrastructure/tasks/setup_aws_network.yml
+++ b/roles/infrastructure/tasks/setup_aws_network.yml
@@ -16,18 +16,45 @@
 
 - name: Set up AWS VPC
   when: not infra__aws_vpc_id
-  amazon.aws.ec2_vpc_net:
-    region: "{{ infra__region }}"
-    name: "{{ infra__vpc_name }}"
-    cidr_block: "{{ infra__vpc_cidr }}"
-    tags: "{{ infra__tags }}" # TODO - Filter out name, per module warning
-    state: present
-  register: __aws_vpc_info
+  block:
+    - name: Create AWS VPC
+      amazon.aws.ec2_vpc_net:
+        region: "{{ infra__region }}"
+        name: "{{ infra__vpc_name }}"
+        cidr_block: "{{ infra__vpc_cidr }}"
+        tags: "{{ infra__tags }}" # TODO - Filter out name, per module warning
+        state: present
+      register: __aws_vpc_info
 
-- name: Set fact for AWS VPC ID
-  when: not infra__aws_vpc_id
-  ansible.builtin.set_fact:
-    infra__aws_vpc_id: "{{ __aws_vpc_info.vpc.id }}"
+    - name: Set fact for AWS VPC ID
+      when: not infra__aws_vpc_id
+      ansible.builtin.set_fact:
+        infra__aws_vpc_id: "{{ __aws_vpc_info.vpc.id }}"
+
+- name: Update existing AWS VPC
+  when: infra__aws_vpc_id
+  block:
+    - name: Update AWS VPC
+      when: no # Skipped due to https://github.com/boto/boto3/issues/2929
+      amazon.aws.ec2_vpc_net:
+        region: "{{ infra__region }}"
+        name: "{{ infra__vpc_name }}"
+        cidr_block: "{{ infra__vpc_cidr }}"
+        tags: "{{ infra__tags }}" # TODO - Filter out name, per module warning
+        state: present
+      register: __aws_vpc_info
+
+    - name: Prepare AWS VPC tags (CLI version)
+      ansible.builtin.set_fact:
+        __aws_vpc_tags: "{{ __aws_vpc_tags | default([]) | union([tag_entry]) }}"
+      vars:
+        tag_entry: "Key={{ __tag.key }},Value={{ __tag.value }}"
+      loop: "{{ infra__tags }}"
+      loop_control:
+        loop_var: __tag
+
+    - name: Update AWS VPC (CLI version)
+      ansible.builtin.command: "aws ec2 create-tags --region {{ infra__region }} --resources {{ infra__aws_vpc_id }} --tags {{ __aws_vpc_tags | join(' ') }}"
 
 - name: Update existing AWS VPC Public and Private Subnets
   when: infra__aws_subnet_ids is defined

--- a/roles/infrastructure/tasks/teardown_aws_network.yml
+++ b/roles/infrastructure/tasks/teardown_aws_network.yml
@@ -19,7 +19,7 @@
 # Note that if the VPC is not shared, but is supplied via direct VpcId or discovered via Name/CIDR, the role will attempt to destroy it
 
 - name: Tear down AWS Security Groups
-  when: infra__teardown_deletes_network and infra__aws_vpc_id
+  when: infra__teardown_deletes_network and infra__aws_vpc_id != ""
   amazon.aws.ec2_group:
     region: "{{ infra__region }}"
     vpc_id: "{{ infra__aws_vpc_id }}"
@@ -32,12 +32,22 @@
     - "{{ infra__security_group_default_name }}"
 
 - name: Tear down AWS Network
-  when: infra__teardown_deletes_network and infra__aws_vpc_id and not infra__aws_subnet_ids
+  when: infra__teardown_deletes_network and infra__aws_subnet_ids is undefined and infra__aws_vpc_id != ""
   block:
     - name: Remove the AWS Private Network
       when: infra__tunnel
       block:
-        - name: Delete the AWS Private Route Tables
+        - name: Delete the AWS Private Route Table
+          when: not infra__public_endpoint_access
+          community.aws.ec2_vpc_route_table:
+            vpc_id: "{{ infra__aws_vpc_id }}"
+            region: "{{ infra__region }}"
+            lookup: tag
+            tags: "{{ { 'Name': infra__aws_private_route_table_name } }}"
+            state: absent
+
+        - name: Delete the AWS Private Route Tables for Public Endpoint Access
+          when: infra__public_endpoint_access
           community.aws.ec2_vpc_route_table:
             vpc_id: "{{ infra__aws_vpc_id }}"
             region: "{{ infra__region }}"
@@ -48,7 +58,8 @@
             index_var: __aws_private_subnet_id_index
           loop: "{{ infra__vpc_private_subnet_cidrs }}"
 
-        - name: List all managed AWS NAT Gateways
+        - name: List all managed AWS NAT Gateways for Public Endpoint Access
+          when: infra__public_endpoint_access 
           community.aws.ec2_vpc_nat_gateway_info:
             region: "{{ infra__region }}"
             filters:
@@ -56,6 +67,7 @@
           register: __aws_all_ngws
 
         - name: Delete associated AWS NAT Gateways
+          when: infra__public_endpoint_access
           community.aws.ec2_vpc_nat_gateway:
             state: absent
             region: "{{ infra__region }}"
@@ -87,6 +99,7 @@
       loop: "{{ infra__vpc_public_subnet_cidrs | union(infra__vpc_private_subnet_cidrs) }}"
 
     - name: Remove AWS Internet Gateway (IGW)
+      when: infra__tunnel and infra__public_endpoint_access
       community.aws.ec2_vpc_igw:
         region: "{{ infra__region }}"
         vpc_id: "{{ infra__aws_vpc_id }}"

--- a/roles/infrastructure/tasks/teardown_aws_network.yml
+++ b/roles/infrastructure/tasks/teardown_aws_network.yml
@@ -14,25 +14,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Tear down AWS Network
-  when: infra__aws_vpc_id | length > 1 and infra__teardown_deletes_network
-  block:
-    - name: Remove Security Groups
-      amazon.aws.ec2_group:
-        region: "{{ infra__region }}"
-        vpc_id: "{{ infra__aws_vpc_id }}"
-        name: "{{ __security_group_name_item }}"
-        state: absent
-      loop_control:
-        loop_var: __security_group_name_item
-      loop:
-        - "{{ infra__security_group_knox_name }}"
-        - "{{ infra__security_group_default_name }}"
+# When infra__aws_subnet_ids is True, then only delete SGs, because the network is not "owned"
+# Otherwise, delete it all unless told otherwise
+# Note that if the VPC is not shared, but is supplied via direct VpcId or discovered via Name/CIDR, the role will attempt to destroy it
 
-    - name: Remove the private networking setup
+- name: Tear down AWS Security Groups
+  when: infra__teardown_deletes_network and infra__aws_vpc_id
+  amazon.aws.ec2_group:
+    region: "{{ infra__region }}"
+    vpc_id: "{{ infra__aws_vpc_id }}"
+    name: "{{ __security_group_name_item }}"
+    state: absent
+  loop_control:
+    loop_var: __security_group_name_item
+  loop:
+    - "{{ infra__security_group_knox_name }}"
+    - "{{ infra__security_group_default_name }}"
+
+- name: Tear down AWS Network
+  when: infra__teardown_deletes_network and infra__aws_vpc_id and not infra__aws_subnet_ids
+  block:
+    - name: Remove the AWS Private Network
       when: infra__tunnel
       block:
-        - name: Delete the private route tables
+        - name: Delete the AWS Private Route Tables
           community.aws.ec2_vpc_route_table:
             vpc_id: "{{ infra__aws_vpc_id }}"
             region: "{{ infra__region }}"
@@ -43,14 +48,14 @@
             index_var: __aws_private_subnet_id_index
           loop: "{{ infra__vpc_private_subnet_cidrs }}"
 
-        - name: List all managed nat gateways within this VPC
+        - name: List all managed AWS NAT Gateways
           community.aws.ec2_vpc_nat_gateway_info:
             region: "{{ infra__region }}"
             filters:
               vpc-id: "{{ infra__aws_vpc_id }}"
           register: __aws_all_ngws
 
-        - name: Delete nat gateway using discovered nat gateways from facts module.
+        - name: Delete associated AWS NAT Gateways
           community.aws.ec2_vpc_nat_gateway:
             state: absent
             region: "{{ infra__region }}"
@@ -63,14 +68,14 @@
           loop: "{{ __aws_all_ngws.result }}"
           ignore_errors: true
 
-        - name: Check if NAT gateways are deleted succesfully
+        - name: Check if AWS NAT Gateways deleted succesfully
           when: __aws_ngw_teardown is defined and __aws_ngw_teardown.results is defined and __aws_ngw_teardown.results | count > 0
           ansible.builtin.fail:
             msg: "Failed to delete a NAT gateway"
           failed_when: item.rc is defined and item.rc != 1 and ('InvalidAllocationID.NotFound' in item.module_stderr)
           loop: "{{ __aws_ngw_teardown.results }}"
 
-    - name: Remove VPC subnets
+    - name: Remove all AWS VPC Subnets
       amazon.aws.ec2_vpc_subnet:
         region: "{{ infra__region }}"
         vpc_id: "{{ infra__aws_vpc_id }}"
@@ -81,7 +86,7 @@
         index_var: __aws_subnet_index
       loop: "{{ infra__vpc_public_subnet_cidrs | union(infra__vpc_private_subnet_cidrs) }}"
 
-    - name: Remove IGW
+    - name: Remove AWS Internet Gateway (IGW)
       community.aws.ec2_vpc_igw:
         region: "{{ infra__region }}"
         vpc_id: "{{ infra__aws_vpc_id }}"
@@ -89,7 +94,7 @@
         tags:
           Name: "{{ infra__aws_igw_name }}"
 
-    - name: Remove VPC, if exists
+    - name: Remove AWS VPC
       amazon.aws.ec2_vpc_net:
         region: "{{ infra__region }}"
         name: "{{ infra__vpc_name }}"


### PR DESCRIPTION
I updated the VPC management to use the wrapped CLI, but kept the buggy module code in for now.

I did some initial testing of just the _infrastructure_, i.e. `ansible-playbook main.yml -e @examples/hybrid/config.yml -vvvvv -t infra`, for:
* L0 (`tunnel: no`, `public_endpoint_access: no`)
* L1 (`tunnel: yes`, `public_endpoint_access: yes`)
* L2 (`tunnel: yes`, `public_endpoint_access: no`)

I also updated the teardown for this infrastructure. Again, I only targeted infrastructure. I also have not tested existing VPC and subnets. If sharing subnets (via RAM), you should only need to specify the subnet IDs, as the VPC ID will be inferred.